### PR TITLE
Fixed crash when processing large, broken or incomplete log entries

### DIFF
--- a/bin/log.js
+++ b/bin/log.js
@@ -45,8 +45,6 @@ lg.stdout.on("data", data => {
     }
   });
 
-  const all = m.map(str => JSON.parse(str));
-
   all.forEach(({ timestamp, eventMessage }) => {
     const time = new Date(timestamp).toLocaleTimeString([], { hour12: false });
     console.log([time, eventMessage].join(", "));

--- a/bin/log.js
+++ b/bin/log.js
@@ -34,6 +34,16 @@ lg.stdout.on("data", data => {
   // Assumption: { is always at the end of a line, } at the start of line.
   const m = str.match(/\{$[\s\S]+?^\}/gm);
   if (m === null) return;
+  
+  const all = m.map(str => {
+    try {
+      return JSON.parse(str);
+    } catch(error) {
+      // Cannot parse - it can happen with certain log entries (maybe large, truncated ones)
+      // In that case, ignore the error and return the plain string.
+      return { timestamp: Date.now(), eventMessage: str };
+    }
+  });
 
   const all = m.map(str => JSON.parse(str));
 


### PR DESCRIPTION
## Proposed changes

With certain log entries, the application crashes with an error like this:

```
SyntaxError: Unexpected token , in JSON at position 138
    at JSON.parse (<anonymous>)
    at /Users/laurent/.npm-global/lib/node_modules/react-native-log-ios/bin/log.js:39:17
    at Array.map (<anonymous>)
    at Socket.<anonymous> (/Users/laurent/.npm-global/lib/node_modules/react-native-log-ios/bin/log.js:38:17)
    at Socket.emit (events.js:210:5)
    at addChunk (_stream_readable.js:326:12)
    at readableAddChunk (_stream_readable.js:301:11)
    at Socket.Readable.push (_stream_readable.js:235:10)
    at Pipe.onStreamRead (internal/stream_base_commons.js:182:23)
```

The log entry is a bit messy so I think it might be broken or truncated. In any case, with this change, such entries will no longer crash the app - instead they will be displayed as-is without parsing.
