### PR TITLE
Fix Xcode spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 
 This standalone script replace the broken `react-native log-ios`.  
-It will watch the Mac OS X system log file and filter only the lines concerning your XCode project.  
+It will watch the macOS system log file and filter only the lines concerning your Xcode project.  
 You will be able to see the `console.log`, `console.warn` and `console.error` outputs.  
 
 

--- a/bin/log.js
+++ b/bin/log.js
@@ -7,7 +7,7 @@ let projectName;
 
 program
   .version("1.0.0")
-  .usage("react-native-log-ios <XCode Project Name>")
+  .usage("react-native-log-ios <Xcode Project Name>")
   .arguments("<xcodeProjectName>")
   .action(xcodeProjectName => (projectName = xcodeProjectName))
   .parse(process.argv);
@@ -26,7 +26,7 @@ const logArgs = [
 
 const lg = spawn("log", logArgs);
 
-console.log("React Native iOS Logger started for XCode project", projectName);
+console.log("React Native iOS Logger started for Xcode project", projectName);
 
 lg.stdout.on("data", data => {
   const str = data.toString();


### PR DESCRIPTION
Just a minor capitalization fix: `XCode` -> `Xcode`